### PR TITLE
Create users in firestore

### DIFF
--- a/src/clients/auth-client.js
+++ b/src/clients/auth-client.js
@@ -1,29 +1,28 @@
-import httpClient from './http';
 import { db } from '../config/firebase-config';
 
+const PASSWORD_PROVIDER_ID = 'password';
 const GOOGLE_PROVIDER_ID = 'google.com';
 const FACEBOOK_PROVIDER_ID = 'facebook.com';
 
-const isGoogleProvider = ({ providerId }) => providerId === GOOGLE_PROVIDER_ID;
-const isFacebookProvider = ({ providerId }) =>
-  providerId === FACEBOOK_PROVIDER_ID;
-
-export const createUser = async ({ user, additionalUserInfo }) => {
-  const isProvider = Boolean(additionalUserInfo);
-
+export const createUser = async ({
+  user,
+  additionalUserInfo,
+  firstName,
+  lastName,
+}) => {
   let values = {
     isAdmin: false,
   };
 
-  if (!isProvider) {
+  if (additionalUserInfo.providerId === PASSWORD_PROVIDER_ID) {
     values = {
       ...values,
-      firstName: user.firstName,
-      lastName: user.lastName,
+      firstName: firstName,
+      lastName: lastName,
     };
   }
 
-  if (isGoogleProvider(additionalUserInfo)) {
+  if (additionalUserInfo.providerId === GOOGLE_PROVIDER_ID) {
     const {
       profile: { given_name: firstName, family_name: lastName },
     } = additionalUserInfo;
@@ -35,7 +34,7 @@ export const createUser = async ({ user, additionalUserInfo }) => {
     };
   }
 
-  if (isFacebookProvider(additionalUserInfo)) {
+  if (additionalUserInfo.providerId === FACEBOOK_PROVIDER_ID) {
     const {
       profile: { first_name: firstName, last_name: lastName },
     } = additionalUserInfo;

--- a/src/clients/auth-client.js
+++ b/src/clients/auth-client.js
@@ -4,14 +4,16 @@ const PASSWORD_PROVIDER_ID = 'password';
 const GOOGLE_PROVIDER_ID = 'google.com';
 const FACEBOOK_PROVIDER_ID = 'facebook.com';
 
-export const createUser = async ({
+export const createUserInFirestore = async ({
   user,
   additionalUserInfo,
   firstName,
   lastName,
+  email,
 }) => {
   let values = {
     isAdmin: false,
+    email: email || user.email,
   };
 
   if (additionalUserInfo.providerId === PASSWORD_PROVIDER_ID) {
@@ -53,5 +55,5 @@ export const createUser = async ({
 };
 
 export default {
-  createUser,
+  createUserInFirestore,
 };

--- a/src/components/Layout/DropDownMenu.jsx
+++ b/src/components/Layout/DropDownMenu.jsx
@@ -56,11 +56,6 @@ const DropDownMenu = (props) => {
     profile,
   } = props;
 
-  let displayName = props.auth.displayName;
-  if (!displayName && profile.name) {
-    displayName = profile.name.displayName;
-  }
-
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -70,17 +65,15 @@ const DropDownMenu = (props) => {
   };
 
   const getUppercaseIntials = (firstName, lastName) => {
-    return 'name'; // firstName.charAt(0).toUpperCase() + lastName.charAt(0).toUpperCase();
+    return firstName.charAt(0).toUpperCase() + lastName.charAt(0).toUpperCase();
   };
 
   const renderAvatar = () => {
-    const { name } = profile;
+    const { firstName, lastName } = profile;
     return Boolean(photoURL) ? (
       <Avatar className={classes.avatar} aria-haspopup='true' src={photoURL} />
     ) : (
-      <Avatar>
-        {name && getUppercaseIntials(name.firstName, name.lastName)}
-      </Avatar>
+      <Avatar>{firstName && getUppercaseIntials(firstName, lastName)}</Avatar>
     );
   };
 
@@ -104,7 +97,7 @@ const DropDownMenu = (props) => {
           <Paper className={classes.paper} elevation={0}>
             <div className={classes.avatar}>{renderAvatar()}</div>
             <div className={classes.information}>
-              <Typography>{displayName}</Typography>
+              <Typography>{`${profile.firstName} ${profile.lastName}`}</Typography>
               <Typography className={classes.email} variant='subtitle2'>
                 {email}
               </Typography>

--- a/src/config/firebase-config.js
+++ b/src/config/firebase-config.js
@@ -30,4 +30,6 @@ export const uiConfig = {
 
 firebase.initializeApp(config);
 
+export const db = firebase.firestore();
+
 export default firebase;

--- a/src/config/firebase-config.js
+++ b/src/config/firebase-config.js
@@ -23,7 +23,7 @@ export const uiConfig = {
   ],
   callbacks: {
     signInSuccessWithAuthResult: (data) => {
-      authClient.createUser(data);
+      authClient.createUserInFirestore(data);
     },
   },
 };

--- a/src/store/slices/auth/actions.js
+++ b/src/store/slices/auth/actions.js
@@ -9,10 +9,11 @@ export const register = (input) => async (dispatch) => {
       .auth()
       .createUserWithEmailAndPassword(email, password);
 
-    await authClient.createUser({
+    await authClient.createUserInFirestore({
       ...user,
       firstName,
       lastName,
+      email,
     });
 
     dispatch(actionCreators.registerSuccess());

--- a/src/store/slices/auth/actions.js
+++ b/src/store/slices/auth/actions.js
@@ -10,7 +10,9 @@ export const register = (input) => async (dispatch) => {
       .createUserWithEmailAndPassword(email, password);
 
     await authClient.createUser({
-      user: { ...user.user, firstName, lastName },
+      ...user,
+      firstName,
+      lastName,
     });
 
     dispatch(actionCreators.registerSuccess());


### PR DESCRIPTION
**what**
This PR changes the user creation logic. We want to create the users in a `users` collection in Firestore.

**why**
Because we want to have all the information related to users on google cloud where it is easier to manage them in one place.

Related to [#39](https://github.com/CodePhenom/schedu-dashboard/issues/39) 